### PR TITLE
feat: add Credfeto.Services.Startup.Interfaces.Tests to achieve 100% coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- Credfeto.Services.Startup.Interfaces.Tests project to collect code coverage for Credfeto.Services.Startup.Interfaces assembly
 ### Fixed
 ### Changed
 ### Deprecated

--- a/src/Credfeto.Services.Startup.Interfaces.Tests/Credfeto.Services.Startup.Interfaces.Tests.csproj
+++ b/src/Credfeto.Services.Startup.Interfaces.Tests/Credfeto.Services.Startup.Interfaces.Tests.csproj
@@ -1,0 +1,79 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <DebuggerSupport>true</DebuggerSupport>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <Features>strict;flow-analysis</Features>
+    <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>latest</LangVersion>
+    <NoWarn />
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <Nullable>enable</Nullable>
+    <OptimizationPreference>speed</OptimizationPreference>
+    <OutputType>Exe</OutputType>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TieredCompilation>true</TieredCompilation>
+    <TieredPGO>true</TieredPGO>
+    <TreatSpecificWarningsAsErrors />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
+    <!-- error NU1902: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
+  </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />
+  <ItemGroup>
+    <ProjectReference Include="..\Credfeto.Services.Startup.Interfaces\Credfeto.Services.Startup.Interfaces.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.25.2243" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.144.1906" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.CodeAnalysis" Version="7.2.0.1978" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.25.2243" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.98" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SmartAnalyzers.CSharpExtensions.Annotations" Version="4.2.11" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="All" ExcludeAssets="runtime" />
+  </ItemGroup>
+</Project>

--- a/src/Credfeto.Services.Startup.Interfaces.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.Services.Startup.Interfaces.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,23 @@
+using Credfeto.Services.Startup.Interfaces.Tests.Mocks;
+using FunFair.Test.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Credfeto.Services.Startup.Interfaces.Tests;
+
+public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
+{
+    public DependencyInjectionTests(ITestOutputHelper output)
+        : base(output: output, dependencyInjectionRegistration: ConfigureServices) { }
+
+    private static IServiceCollection ConfigureServices(IServiceCollection services)
+    {
+        return services.AddRunOnStartupTask<DummyRunOnStartup>();
+    }
+
+    [Fact]
+    public void DummyRunOnStartupIsRegistered()
+    {
+        this.RequireServiceInCollectionFor<IRunOnStartup, DummyRunOnStartup>();
+    }
+}

--- a/src/Credfeto.Services.Startup.Interfaces.Tests/Mocks/DummyRunOnStartup.cs
+++ b/src/Credfeto.Services.Startup.Interfaces.Tests/Mocks/DummyRunOnStartup.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Services.Startup.Interfaces;
+
+namespace Credfeto.Services.Startup.Interfaces.Tests.Mocks;
+
+public sealed class DummyRunOnStartup : IRunOnStartup
+{
+    public ValueTask StartAsync(CancellationToken cancellationToken)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Credfeto.Services.Startup.slnx
+++ b/src/Credfeto.Services.Startup.slnx
@@ -6,6 +6,7 @@
     <File Path="global.json" />
   </Folder>
   <Project Path="Credfeto.Services.Startup.Interfaces/Credfeto.Services.Startup.Interfaces.csproj" />
+  <Project Path="Credfeto.Services.Startup.Interfaces.Tests/Credfeto.Services.Startup.Interfaces.Tests.csproj" />
   <Project Path="Credfeto.Services.Startup.Tests/Credfeto.Services.Startup.Tests.csproj" />
   <Project Path="Credfeto.Services.Startup/Credfeto.Services.Startup.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

- Adds `Credfeto.Services.Startup.Interfaces.Tests` project to instrument coverage for `Credfeto.Services.Startup.Interfaces.dll`
- Root cause: `UnitTests.props` generates a `coverage.settings.xml` that restricts collection to the sister assembly by name (`ProjectName.Replace(".Tests", "")`), so the existing `Credfeto.Services.Startup.Tests` only covered `Credfeto.Services.Startup.dll` — the Interfaces assembly was never included
- `DependencyInjectionTests` verifies that `AddRunOnStartupTask<TService>()` registers `TService` as `IRunOnStartup` singleton, achieving 100% line, branch, and method coverage for `StartupExtensions`
- Added new project to solution (`.slnx`)

## Test plan

- [ ] `dotnet test Credfeto.Services.Startup.Interfaces.Tests` passes
- [ ] Coverage report includes `Credfeto.Services.Startup.Interfaces` with `line-rate="1" branch-rate="1"`
- [ ] All existing tests continue to pass

Closes #51