### PR TITLE
test: add null-argument tests to achieve 100% branch coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 - Credfeto.Services.Startup.Interfaces.Tests project to collect code coverage for Credfeto.Services.Startup.Interfaces assembly
+- Unit tests to achieve 100% branch coverage in Credfeto.Services.Startup
 ### Fixed
 ### Changed
 ### Deprecated

--- a/src/Credfeto.Services.Startup.Tests/LogOnProcessStartupTests.cs
+++ b/src/Credfeto.Services.Startup.Tests/LogOnProcessStartupTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.Services.Startup.Tests;
+
+public sealed class LogOnProcessStartupTests : TestBase
+{
+    [Fact]
+    public void LoggerIsRequired()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+            new LogOnProcessStartup(logger: null!)
+        );
+
+        Assert.Equal(expected: "logger", actual: exception.ParamName);
+    }
+}

--- a/src/Credfeto.Services.Startup.Tests/StartupServiceTests.cs
+++ b/src/Credfeto.Services.Startup.Tests/StartupServiceTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Credfeto.Services.Startup.Interfaces;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Credfeto.Services.Startup.Tests;
+
+public sealed class StartupServiceTests : TestBase
+{
+    [Fact]
+    public void ServicesIsRequired()
+    {
+        ILogger<StartupService> logger = NullLogger<StartupService>.Instance;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+            new StartupService(services: null!, logger: logger)
+        );
+
+        Assert.Equal(expected: "services", actual: exception.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `LogOnProcessStartupTests` to test that passing `null` for `logger` throws `ArgumentNullException` with `paramName = "logger"`
- Add `StartupServiceTests` to test that passing `null` for `services` throws `ArgumentNullException` with `paramName = "services"`
- Branch coverage for `Credfeto.Services.Startup` increased from 75% (6/8) to 100% (8/8)

Closes #52